### PR TITLE
Remove payee name field from cheque verification

### DIFF
--- a/api/src/services/chequeService.ts
+++ b/api/src/services/chequeService.ts
@@ -8,13 +8,11 @@ interface ChequeRow {
   CHEQUE_STATUS_OUTPUT: string;
   CHEQUE_NUMBER: number;
   PAYMENT_ISSUE_DT: Date;
-  PAYEE_NAME: string;
-  PAYEE_TYPE: string;
   APPLIED_AMOUNT: number;
 }
 
 export async function getChequeFromDatabase(
-    chequeNumber: number
+  chequeNumber: number
 ): Promise<ChequeStatusResponse> {
   let connection: oracledb.Connection | undefined;
   let result: oracledb.Result<ChequeRow> | undefined;
@@ -23,7 +21,9 @@ export async function getChequeFromDatabase(
   const table = process.env.DB_TABLE;
 
   if (!schema || !table) {
-    throw new Error("Database schema and table not configured in environment variables");
+    throw new Error(
+      "Database schema and table not configured in environment variables"
+    );
   }
 
   try {
@@ -31,11 +31,11 @@ export async function getChequeFromDatabase(
     connection = await dbPool.getConnection();
 
     result = await connection.execute<ChequeRow>(
-        `SELECT CHEQUE_STATUS_OUTPUT, CHEQUE_NUMBER, PAYMENT_ISSUE_DT, PAYEE_NAME, PAYEE_TYPE, APPLIED_AMOUNT
+      `SELECT CHEQUE_STATUS_OUTPUT, CHEQUE_NUMBER, PAYMENT_ISSUE_DT, APPLIED_AMOUNT
        FROM ${schema}.${table}
        WHERE CHEQUE_NUMBER = :chequeNumber`,
-        { chequeNumber },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT }
+      { chequeNumber },
+      { outFormat: oracledb.OUT_FORMAT_OBJECT }
     );
   } catch (error) {
     console.error("Database error in getChequeFromDatabase:", error);
@@ -53,14 +53,14 @@ export async function getChequeFromDatabase(
     chequeStatus: row.CHEQUE_STATUS_OUTPUT,
     chequeNumber: row.CHEQUE_NUMBER,
     paymentIssueDate: row.PAYMENT_ISSUE_DT,
-    payeeName: row.PAYEE_NAME,
-    payeeType: row.PAYEE_TYPE,
     appliedAmount: row.APPLIED_AMOUNT,
   };
 }
 
 // Extract connection cleanup into a separate function
-async function closeConnection(connection: oracledb.Connection | undefined): Promise<void> {
+async function closeConnection(
+  connection: oracledb.Connection | undefined
+): Promise<void> {
   if (connection) {
     try {
       await connection.close();

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -3,8 +3,6 @@ export interface ChequeStatusResponse {
   chequeStatus: string;
   chequeNumber: number;
   paymentIssueDate: Date;
-  payeeName: string;
-  payeeType: string;
   appliedAmount: number;
 }
 

--- a/backend/src/controllers/chequeController.ts
+++ b/backend/src/controllers/chequeController.ts
@@ -20,8 +20,7 @@ export class ChequeController {
    */
   async verifyCheque(req: Request, res: Response): Promise<void> {
     try {
-      const { chequeNumber, payeeName, appliedAmount, paymentIssueDate } =
-        req.body;
+      const { chequeNumber, appliedAmount, paymentIssueDate } = req.body;
 
       // Validate cheque number
       if (!chequeNumber) {
@@ -41,7 +40,6 @@ export class ChequeController {
 
       // Validate verification fields
       const validation = this.chequeService.validateVerificationFields(
-        payeeName,
         appliedAmount,
         paymentIssueDate
       );
@@ -69,7 +67,7 @@ export class ChequeController {
 
       // Verify user input against actual data
       const verificationErrors = this.chequeService.verifyFields(
-        { payeeName, appliedAmount, paymentIssueDate },
+        { appliedAmount, paymentIssueDate },
         apiResponse.data
       );
 

--- a/backend/src/services/chequeVerificationService.ts
+++ b/backend/src/services/chequeVerificationService.ts
@@ -24,21 +24,19 @@ export class ChequeVerificationService {
 
   /**
    * Validates required verification fields
-   * @param payeeName - Payee name
    * @param appliedAmount - Applied amount
    * @param paymentIssueDate - Payment issue date
    * @returns object with isValid boolean and error message if invalid
    */
   validateVerificationFields(
-    payeeName: string,
     appliedAmount: string,
     paymentIssueDate: string
   ): { isValid: boolean; error?: string } {
-    if (!payeeName || !appliedAmount || !paymentIssueDate) {
+    if (!appliedAmount || !paymentIssueDate) {
       return {
         isValid: false,
         error:
-          "All verification fields are required (payeeName, appliedAmount, paymentIssueDate)",
+          "All verification fields are required (appliedAmount, paymentIssueDate)",
       };
     }
 
@@ -88,63 +86,12 @@ export class ChequeVerificationService {
    */
   verifyFields(
     userInput: {
-      payeeName: string;
       appliedAmount: string;
       paymentIssueDate: string;
     },
     actualData: ChequeStatusResponse
   ): string[] {
     const verificationErrors: string[] = [];
-
-    // Verify payee name (case-insensitive with multiple format handling)
-    let payeeNameMatches = false;
-    const dbName = actualData.payeeName.toLowerCase().trim();
-    const userName = userInput.payeeName.toLowerCase().trim();
-
-    // Method 1: Exact match
-    if (dbName === userName) {
-      payeeNameMatches = true;
-    } else {
-      // Method 2: Check if database format is "Last, First" and user entered "First Last"
-      if (dbName.includes(",")) {
-        const [lastName, firstName] = dbName
-          .split(",")
-          .map((part) => part.trim());
-        const reconstructed = `${firstName} ${lastName}`;
-
-        if (reconstructed === userName) {
-          payeeNameMatches = true;
-        }
-      }
-
-      // Method 3: Check if user entered "Last, First" and database has "First Last"
-      if (!payeeNameMatches && userName.includes(",")) {
-        const [lastName, firstName] = userName
-          .split(",")
-          .map((part) => part.trim());
-        const reconstructed = `${firstName} ${lastName}`;
-
-        if (reconstructed === dbName) {
-          payeeNameMatches = true;
-        }
-      }
-
-      // Method 4: Try reversing the database name if it doesn't have comma
-      if (!payeeNameMatches && !dbName.includes(",") && dbName.includes(" ")) {
-        const nameParts = dbName.split(" ");
-        if (nameParts.length === 2) {
-          const reversed = `${nameParts[1]} ${nameParts[0]}`;
-
-          if (reversed === userName) {
-            payeeNameMatches = true;
-          }
-        }
-      }
-    }
-
-    if (!payeeNameMatches) {
-      verificationErrors.push("Payee name does not match");
-    }
 
     // Verify applied amount (with tolerance for floating point precision)
     const providedAmount = parseFloat(userInput.appliedAmount);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -3,8 +3,6 @@ export interface ChequeStatusResponse {
   chequeStatus: string;
   chequeNumber: number;
   paymentIssueDate: Date;
-  payeeName: string;
-  payeeType: string;
   appliedAmount: number;
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import type { ApiResponse, CheckStatus } from "./types";
 
 function App() {
   const [chequeNumber, setChequeNumber] = useState("");
-  const [payeeName, setPayeeName] = useState("");
   const [paymentIssueDate, setPaymentIssueDate] = useState("");
   const [appliedAmount, setAppliedAmount] = useState("");
   const [status, setStatus] = useState<ApiResponse<CheckStatus> | null>(null);
@@ -18,12 +17,6 @@ function App() {
     // Validate all required fields
     if (!chequeNumber.trim()) {
       setError("Please enter a cheque number");
-      setStatus(null);
-      return;
-    }
-
-    if (!payeeName.trim()) {
-      setError("Please enter a payee name");
       setStatus(null);
       return;
     }
@@ -50,7 +43,6 @@ function App() {
         `${apiUrl}/api/cheque/verify`,
         {
           chequeNumber,
-          payeeName,
           paymentIssueDate,
           appliedAmount,
         }
@@ -209,44 +201,6 @@ function App() {
                 value={chequeNumber}
                 onChange={(e) => setChequeNumber(e.target.value)}
                 placeholder="Enter your cheque number"
-                style={{
-                  width: "100%",
-                  padding: "12px 16px",
-                  border: `1px solid var(--bcgov-border-light)`,
-                  borderRadius: "6px",
-                  outline: "none",
-                  fontSize: "16px",
-                  fontFamily: "BCSans, sans-serif",
-                }}
-                onFocus={(e) =>
-                  (e.target.style.borderColor = "var(--bcgov-border-active)")
-                }
-                onBlur={(e) =>
-                  (e.target.style.borderColor = "var(--bcgov-border-light)")
-                }
-                required
-              />
-            </div>
-
-            <div style={{ marginBottom: "24px" }}>
-              <label
-                htmlFor="payeeName"
-                style={{
-                  display: "block",
-                  color: "var(--bcgov-text-primary)",
-                  fontFamily: "BCSans, sans-serif",
-                  fontWeight: "500",
-                  marginBottom: "8px",
-                }}
-              >
-                Payee Name:
-              </label>
-              <input
-                type="text"
-                id="payeeName"
-                value={payeeName}
-                onChange={(e) => setPayeeName(e.target.value)}
-                placeholder="Enter the payee name"
                 style={{
                   width: "100%",
                   padding: "12px 16px",


### PR DESCRIPTION
Eliminated the payee name field and related logic from frontend, backend controller, service, and shared types. Cheque verification now only requires applied amount and payment issue date, simplifying the verification process.