### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/cheque-verification/security/code-scanning/4](https://github.com/bcgov/cheque-verification/security/code-scanning/4)

The best way to fix the issue is to set the `permissions` key so that the jobs have only the minimum privileges required. Since the workflow includes code that uses actions like `actions/checkout`, uploads artifacts, and interacts with SonarCloud, but does not appear to require write access to the code, the minimal safe default is `contents: read`. This can be done at the workflow (top/root) level, applying to all jobs, or at the job level for more granular control.

Because none of the jobs need more than read access (they're running tests, gathering/using coverage, and pushing nothing back), setting `permissions: contents: read` at the root of the workflow file (right after `name:` and before `on:`) will most simply adhere to the least privilege principle.

- **Add a `permissions:` block at the top of `.github/workflows/ci.yml`, directly after the `name` line and before `on:`.**
- Set `contents: read` under `permissions:`.
- No other changes, imports, or logic needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
