### PR TITLE
Add JWT authentication to API and backend services

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -27,3 +27,9 @@ JWT_CLOCK_TOLERANCE=10
 # Optional: JWT algorithm (default: HS256)
 # JWT_ALGORITHM=HS256
 
+# Rate Limiting Configuration
+# Window in minutes
+RATE_LIMIT_WINDOW_MINUTES=15
+# Max requests per window (default: 10 - reasonable for 600 requests/day total)
+RATE_LIMIT_MAX_REQUESTS=10
+

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,14 +1,29 @@
-# Oracle Database Connection Settings
-ORACLE_USER=your_oracle_username
-ORACLE_PASSWORD=your_oracle_password
-ORACLE_CONNECTION_STRING=localhost:1521/your_service_name
+PORT=3000
 
-# Database schema and table
+# Database Configuration
 DB_SCHEMA=your_schema_name
 DB_TABLE=your_table_name
+# Oracle DB connection details
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=your_db_host
+DB_PORT=1521
+DB_SERVICE=your_service_name
 
-# API Settings
-PORT=port
+# CORS allowlist for backend callers
+BACKEND_URL=http://localhost:4000
+# Optional additional allowed origin for production internal URL
+# BACKEND_PROD_URL=
 
-# Environment (development, production, test)
-NODE_ENV=development
+# JWT verification settings
+# Set AUTH_DISABLED=true to bypass JWT in local dev/tests
+AUTH_DISABLED=false
+JWT_SECRET=replace_me_with_secure_secret_at_least_32_chars
+JWT_ISSUER=cheque-backend
+JWT_AUDIENCE=cheque-api
+# Clock skew tolerance in seconds (default: 10)
+JWT_CLOCK_TOLERANCE=10
+
+# Optional: JWT algorithm (default: HS256)
+# JWT_ALGORITHM=HS256
+

--- a/api/__tests__/integration/api.test.ts
+++ b/api/__tests__/integration/api.test.ts
@@ -3,6 +3,17 @@ import express from "express";
 import routes from "../../src/routes";
 import { HttpError } from "../../src/middleware/validation";
 
+// Mock express-rate-limit to disable rate limiting in tests
+jest.mock("express-rate-limit", () => {
+  return jest.fn(() => (req: any, res: any, next: any) => next());
+});
+
+// Mock the authentication middleware to disable JWT for tests
+jest.mock("../../src/middleware/auth", () => ({
+  authenticateJWT: (req: any, res: any, next: any) => next(),
+  validateJWTClaims: () => (req: any, res: any, next: any) => next(),
+}));
+
 // Mock the entire cheque service module
 jest.mock("../../src/services/chequeService", () => ({
   getChequeFromDatabase: jest.fn(),

--- a/api/__tests__/integration/server.test.ts
+++ b/api/__tests__/integration/server.test.ts
@@ -7,13 +7,19 @@ jest.mock("../../src/config/database", () => ({
   closeDbPool: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Mock the authentication middleware to disable JWT for tests
+jest.mock("../../src/middleware/auth", () => ({
+  authenticateJWT: (req: any, res: any, next: any) => next(),
+  validateJWTClaims: () => (req: any, res: any, next: any) => next(),
+}));
+
 describe("API Server Integration", () => {
   let app: express.Application;
 
   beforeAll(async () => {
-    // Import the app from index.ts
-    const { app: mainApp } = require("../../src/index");
-    app = mainApp;
+    // Import the app without starting the server
+    const { app: exportedApp } = require("../../src/index");
+    app = exportedApp;
   });
 
   describe("Server Configuration", () => {

--- a/api/__tests__/setup.ts
+++ b/api/__tests__/setup.ts
@@ -14,6 +14,9 @@ beforeAll(async () => {
   process.env.DB_SCHEMA = process.env.TEST_DB_SCHEMA || "TEST_SCHEMA";
   process.env.DB_TABLE = process.env.TEST_DB_TABLE || "TEST_CHEQUES";
 
+  // Disable auth checks in tests
+  process.env.AUTH_DISABLED = "true";
+
   // Suppress console.log during tests unless debugging
   if (!process.env.DEBUG_TESTS) {
     console.log = jest.fn();

--- a/api/__tests__/unit/auth.test.ts
+++ b/api/__tests__/unit/auth.test.ts
@@ -1,0 +1,358 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { authenticateJWT, validateJWTClaims } from "../../src/middleware/auth";
+
+// Mock jsonwebtoken
+jest.mock("jsonwebtoken");
+const mockedJwt = jwt as jest.Mocked<typeof jwt>;
+
+describe("Auth Middleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.MockedFunction<NextFunction>;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset environment - ensure AUTH_DISABLED is not set by default
+    process.env = {
+      ...originalEnv,
+      AUTH_DISABLED: undefined,
+    };
+    delete process.env.AUTH_DISABLED;
+
+    // Setup mock request/response objects
+    req = {
+      path: "/api/v1/cheque/123456",
+      header: jest.fn(),
+    } as Partial<Request>;
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    next = jest.fn();
+
+    // Clear all mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("authenticateJWT", () => {
+    describe("when AUTH_DISABLED is true", () => {
+      it("should bypass authentication and call next()", () => {
+        process.env.AUTH_DISABLED = "true";
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when path includes /health", () => {
+      it("should bypass authentication for health check endpoints", () => {
+        // Create a new request object with health path
+        const healthReq = {
+          ...req,
+          path: "/health",
+        } as Request;
+        process.env.JWT_SECRET = "test-secret";
+
+        authenticateJWT(healthReq, res as Response, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+
+      it("should bypass authentication for nested health endpoints", () => {
+        // Create a new request object with nested health path
+        const healthReq = {
+          ...req,
+          path: "/api/v1/health",
+        } as Request;
+        process.env.JWT_SECRET = "test-secret";
+
+        authenticateJWT(healthReq, res as Response, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when JWT_SECRET is not configured", () => {
+      it("should return 500 error", () => {
+        delete process.env.JWT_SECRET;
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Server authentication is not configured",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when Authorization header is missing", () => {
+      it("should return 401 error for missing header", () => {
+        process.env.JWT_SECRET = "test-secret";
+        (req.header as jest.Mock).mockReturnValue(undefined);
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Authorization header with Bearer token required",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+
+      it("should return 401 error for non-Bearer header", () => {
+        process.env.JWT_SECRET = "test-secret";
+        (req.header as jest.Mock).mockReturnValue("Basic token123");
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Authorization header with Bearer token required",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when token is empty", () => {
+      it("should return 401 error for Bearer without token", () => {
+        process.env.JWT_SECRET = "test-secret";
+        (req.header as jest.Mock).mockReturnValue("Bearer ");
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Token is required",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when token verification succeeds", () => {
+      it("should call next() and attach payload to request", () => {
+        process.env.JWT_SECRET = "test-secret";
+        process.env.JWT_ISSUER = "test-issuer";
+        process.env.JWT_AUDIENCE = "test-audience";
+        process.env.JWT_CLOCK_TOLERANCE = "15";
+
+        const mockPayload = { sub: "test-user", exp: Date.now() + 3600 };
+        (req.header as jest.Mock).mockReturnValue("Bearer valid-token");
+        (mockedJwt.verify as jest.Mock).mockReturnValue(mockPayload);
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(mockedJwt.verify).toHaveBeenCalledWith(
+          "valid-token",
+          "test-secret",
+          {
+            algorithms: ["HS256"],
+            issuer: "test-issuer",
+            audience: "test-audience",
+            clockTolerance: 15,
+          }
+        );
+        expect(req.jwtPayload).toBe(mockPayload);
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+
+      it("should use default values when env vars not set", () => {
+        process.env.JWT_SECRET = "test-secret";
+        // Don't set JWT_ISSUER, JWT_AUDIENCE, or JWT_CLOCK_TOLERANCE
+
+        const mockPayload = { sub: "test-user" };
+        (req.header as jest.Mock).mockReturnValue("Bearer valid-token");
+        (mockedJwt.verify as jest.Mock).mockReturnValue(mockPayload);
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(mockedJwt.verify).toHaveBeenCalledWith(
+          "valid-token",
+          "test-secret",
+          {
+            algorithms: ["HS256"],
+            issuer: undefined,
+            audience: undefined,
+            clockTolerance: 10, // Default value
+          }
+        );
+        expect(next).toHaveBeenCalled();
+      });
+    });
+
+    describe("when token verification fails", () => {
+      beforeEach(() => {
+        process.env.JWT_SECRET = "test-secret";
+        (req.header as jest.Mock).mockReturnValue("Bearer invalid-token");
+      });
+
+      it("should return 401 for expired token", () => {
+        (mockedJwt.verify as jest.Mock).mockImplementation(() => {
+          throw new jwt.TokenExpiredError("Token expired", new Date());
+        });
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Token has expired",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+
+      it("should return 401 for malformed token", () => {
+        (mockedJwt.verify as jest.Mock).mockImplementation(() => {
+          throw new jwt.JsonWebTokenError("Invalid token");
+        });
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Invalid token format",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+
+      it("should return 401 for other verification errors", () => {
+        (mockedJwt.verify as jest.Mock).mockImplementation(() => {
+          throw new Error("Some other error");
+        });
+
+        authenticateJWT(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Token verification failed",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("validateJWTClaims", () => {
+    const requiredClaims = {
+      purpose: "cheque-api-access",
+      sub: "cheque-backend-service",
+    };
+
+    describe("when jwtPayload is not present", () => {
+      it("should return 401 error", () => {
+        delete req.jwtPayload;
+
+        const middleware = validateJWTClaims(requiredClaims);
+        middleware(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error:
+            "JWT payload not found. Ensure authenticateJWT middleware runs first.",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when claims match", () => {
+      it("should call next()", () => {
+        req.jwtPayload = {
+          purpose: "cheque-api-access",
+          sub: "cheque-backend-service",
+          iat: Date.now(),
+        };
+
+        const middleware = validateJWTClaims(requiredClaims);
+        middleware(req as Request, res as Response, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when claims don't match", () => {
+      it("should return 403 error for wrong purpose", () => {
+        req.jwtPayload = {
+          purpose: "wrong-purpose",
+          sub: "cheque-backend-service",
+          iat: Date.now(),
+        };
+
+        const middleware = validateJWTClaims(requiredClaims);
+        middleware(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Invalid JWT claims",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+
+      it("should return 403 error for wrong subject", () => {
+        req.jwtPayload = {
+          purpose: "cheque-api-access",
+          sub: "wrong-service",
+          iat: Date.now(),
+        };
+
+        const middleware = validateJWTClaims(requiredClaims);
+        middleware(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Invalid JWT claims",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+
+      it("should return 403 error for missing claims", () => {
+        req.jwtPayload = {
+          iat: Date.now(),
+          // Missing required claims
+        };
+
+        const middleware = validateJWTClaims(requiredClaims);
+        middleware(req as Request, res as Response, next);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({
+          success: false,
+          error: "Invalid JWT claims",
+        });
+        expect(next).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("with no required claims", () => {
+      it("should call next() when no claims required", () => {
+        req.jwtPayload = { iat: Date.now() };
+
+        const middleware = validateJWTClaims({});
+        middleware(req as Request, res as Response, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/api/__tests__/unit/rateLimiting.test.ts
+++ b/api/__tests__/unit/rateLimiting.test.ts
@@ -1,0 +1,63 @@
+import request from "supertest";
+import express from "express";
+import rateLimit from "express-rate-limit";
+
+describe("Rate Limiting", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+
+    // Create a simple rate limiter for testing (very low limits)
+    const testRateLimit = rateLimit({
+      windowMs: 1000, // 1 second window
+      max: 2, // Allow only 2 requests per second for testing
+      message: {
+        error: "Too many requests, please try again later.",
+        retryAfter: "1 second",
+      },
+      standardHeaders: true,
+      legacyHeaders: false,
+    });
+
+    app.use(testRateLimit);
+    app.get("/test", (req, res) => {
+      res.json({ success: true });
+    });
+  });
+
+  it("should allow requests within the rate limit", async () => {
+    // First request should succeed
+    const response1 = await request(app).get("/test").expect(200);
+
+    expect(response1.body).toEqual({ success: true });
+
+    // Second request should also succeed
+    const response2 = await request(app).get("/test").expect(200);
+
+    expect(response2.body).toEqual({ success: true });
+  });
+
+  it("should block requests that exceed the rate limit", async () => {
+    // Make the maximum allowed requests
+    await request(app).get("/test").expect(200);
+    await request(app).get("/test").expect(200);
+
+    // Third request should be rate limited
+    const response = await request(app).get("/test").expect(429);
+
+    expect(response.body).toEqual({
+      error: "Too many requests, please try again later.",
+      retryAfter: "1 second",
+    });
+  });
+
+  it("should include rate limit headers", async () => {
+    const response = await request(app).get("/test").expect(200);
+
+    // Check for standard rate limit headers
+    expect(response.headers).toHaveProperty("ratelimit-limit");
+    expect(response.headers).toHaveProperty("ratelimit-remaining");
+    expect(response.headers).toHaveProperty("ratelimit-reset");
+  });
+});

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,12 +13,14 @@
         "express": "^4.21.2",
         "express-async-errors": "^3.1.1",
         "express-validator": "^7.2.1",
+        "jsonwebtoken": "^9.0.2",
         "oracledb": "^6.8.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^18.19.111",
         "@types/oracledb": "^5.3.1",
         "@types/supertest": "^6.0.3",
@@ -2179,6 +2181,17 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2190,6 +2203,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2656,6 +2676,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3129,6 +3155,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -5543,6 +5578,67 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5589,11 +5685,53 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "express-async-errors": "^3.1.1",
+        "express-rate-limit": "^8.0.1",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "oracledb": "^6.8.0"
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
+        "@types/express-rate-limit": "^5.1.3",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^18.19.111",
@@ -2113,6 +2115,16 @@
         "@types/serve-static": "*"
       }
     },
+    "node_modules/@types/express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-H+TYy3K53uPU2TqPGFYaiWc2xJV6+bIFkDd/Ma2/h67Pa6ARk9kWE0p/K9OH1Okm0et9Sfm66fmXoAxsH2PHXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.19.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
@@ -3460,6 +3472,24 @@
         "express": "^4.16.2"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-validator": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
@@ -3924,6 +3954,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "express-async-errors": "^3.1.1",
+    "express-rate-limit": "^8.0.1",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "oracledb": "^6.8.0"
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.23",
+    "@types/express-rate-limit": "^5.1.3",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^18.19.111",

--- a/api/package.json
+++ b/api/package.json
@@ -20,12 +20,14 @@
     "express": "^4.21.2",
     "express-async-errors": "^3.1.1",
     "express-validator": "^7.2.1",
+    "jsonwebtoken": "^9.0.2",
     "oracledb": "^6.8.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.23",
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^18.19.111",
     "@types/oracledb": "^5.3.1",
     "@types/supertest": "^6.0.3",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -69,10 +69,13 @@ async function startServer() {
   process.on("SIGINT", shutdown);
 }
 
-startServer().catch((err) => {
-  console.error("Startup error:", err);
-  process.exit(1);
-});
+// Only start server if this file is run directly
+if (require.main === module) {
+  startServer().catch((err) => {
+    console.error("Startup error:", err);
+    process.exit(1);
+  });
+}
 
 // Export app for testing
 export { app };

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,0 +1,117 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+// Extend Request interface to include JWT payload
+declare global {
+  namespace Express {
+    interface Request {
+      jwtPayload?: jwt.JwtPayload;
+    }
+  }
+}
+
+/**
+ * JWT authentication middleware for internal API
+ * Bypasses verification when AUTH is disabled (e.g., tests/local dev)
+ */
+export const authenticateJWT = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const authDisabled = process.env.AUTH_DISABLED === "true";
+  const secret = process.env.JWT_SECRET;
+
+  // Allow health checks without auth and allow bypass when disabled
+  if (authDisabled || req.path.includes("/health")) {
+    return next();
+  }
+
+  if (!secret) {
+    return res.status(500).json({
+      success: false,
+      error: "Server authentication is not configured",
+    });
+  }
+
+  const authHeader = req.header("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({
+      success: false,
+      error: "Authorization header with Bearer token required",
+    });
+  }
+
+  const token = authHeader.substring(7);
+  if (!token) {
+    return res.status(401).json({
+      success: false,
+      error: "Token is required",
+    });
+  }
+
+  try {
+    const issuer = process.env.JWT_ISSUER || undefined;
+    const audience = process.env.JWT_AUDIENCE || undefined;
+    const clockTolerance = process.env.JWT_CLOCK_TOLERANCE
+      ? parseInt(process.env.JWT_CLOCK_TOLERANCE, 10)
+      : 10; // Default 10 seconds tolerance
+
+    const payload = jwt.verify(token, secret, {
+      algorithms: ["HS256"],
+      issuer,
+      audience,
+      clockTolerance,
+    }) as jwt.JwtPayload;
+
+    // Attach payload to request for potential downstream use
+    req.jwtPayload = payload;
+
+    return next();
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      return res.status(401).json({
+        success: false,
+        error: "Token has expired",
+      });
+    }
+
+    if (err instanceof jwt.JsonWebTokenError) {
+      return res.status(401).json({
+        success: false,
+        error: "Invalid token format",
+      });
+    }
+
+    return res.status(401).json({
+      success: false,
+      error: "Token verification failed",
+    });
+  }
+};
+
+/**
+ * Optional middleware to validate specific JWT claims
+ */
+export const validateJWTClaims = (requiredClaims: Record<string, any>) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.jwtPayload) {
+      return res.status(401).json({
+        success: false,
+        error:
+          "JWT payload not found. Ensure authenticateJWT middleware runs first.",
+      });
+    }
+
+    for (const [key, expectedValue] of Object.entries(requiredClaims)) {
+      if (req.jwtPayload[key] !== expectedValue) {
+        return res.status(403).json({
+          success: false,
+          error: "Invalid JWT claims",
+        });
+      }
+    }
+
+    next();
+  };
+};

--- a/api/src/routes/cheque.ts
+++ b/api/src/routes/cheque.ts
@@ -1,9 +1,30 @@
 import { Router, Request, Response } from "express";
+import rateLimit from "express-rate-limit";
 import { getChequeFromDatabase } from "../services/chequeService";
 import { validateChequeNumber } from "../middleware/validation";
 import { authenticateJWT, validateJWTClaims } from "../middleware/auth";
 
 const router = Router();
+
+// Rate limiting for cheque API endpoints
+// Allow configurable requests per configurable window (default: 10 requests per 15 minutes)
+// This accommodates the ~600 requests/day total with reasonable per-IP limits
+const windowMinutes = parseInt(process.env.RATE_LIMIT_WINDOW_MINUTES || "15");
+const maxRequests = parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || "10");
+
+const chequeRateLimit = rateLimit({
+  windowMs: windowMinutes * 60 * 1000, // Convert minutes to milliseconds
+  max: maxRequests, // Limit each IP to max requests per windowMs
+  message: {
+    error: "Too many requests from this IP, please try again later.",
+    retryAfter: `${windowMinutes} minutes`,
+  },
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+// Apply rate limiting to all cheque routes
+router.use(chequeRateLimit);
 
 // Apply JWT authentication to all cheque routes
 router.use(authenticateJWT);

--- a/api/src/routes/cheque.ts
+++ b/api/src/routes/cheque.ts
@@ -1,8 +1,20 @@
 import { Router, Request, Response } from "express";
 import { getChequeFromDatabase } from "../services/chequeService";
 import { validateChequeNumber } from "../middleware/validation";
+import { authenticateJWT, validateJWTClaims } from "../middleware/auth";
 
 const router = Router();
+
+// Apply JWT authentication to all cheque routes
+router.use(authenticateJWT);
+
+// Optional: Validate specific JWT claims for extra security
+router.use(
+  validateJWTClaims({
+    purpose: "cheque-api-access",
+    sub: "cheque-backend-service",
+  })
+);
 
 // Main endpoint for cheque verification
 router.get(

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,19 @@
-# Server configuration
-PORT=port
+# Server Configuration
+PORT=4000
+
+# API Service Configuration
+API_URL=http://localhost:3000
+
+# Frontend Configuration
+FRONTEND_URL=http://localhost:5173
+
+# JWT Configuration for API Authentication
+JWT_SECRET=replace_me_with_secure_secret_at_least_32_chars
+JWT_ISSUER=cheque-backend
+JWT_AUDIENCE=cheque-api
+# Token TTL in seconds (default: 120 = 2 minutes)
+JWT_TTL=120
+
+# Environment
 NODE_ENV=development
 
-# Service URLs
-API_URL=http://localhost:port
-FRONTEND_URL=http://localhost:port

--- a/backend/__tests__/integration/server.test.ts
+++ b/backend/__tests__/integration/server.test.ts
@@ -1,13 +1,14 @@
 import request from "supertest";
 import express from "express";
+import { describe, it, expect, beforeAll } from "@jest/globals";
+import { createApp } from "../../src/index";
 
 describe("Backend Server Integration", () => {
   let app: express.Application;
 
   beforeAll(async () => {
-    // Import the app from index.ts
-    const { app: mainApp } = require("../../src/index");
-    app = mainApp;
+    // Create the app instance for testing (without starting server)
+    app = createApp();
   });
 
   describe("Server Configuration", () => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,12 +12,14 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.0.1"
+        "express-rate-limit": "^8.0.1",
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^18.16.0",
         "@types/supertest": "^6.0.2",
         "jest": "^29.7.0",
@@ -2124,6 +2126,17 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2135,6 +2148,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2568,6 +2588,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3022,6 +3048,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -5458,6 +5493,67 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5498,11 +5594,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,12 +19,14 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-rate-limit": "^8.0.1"
+    "express-rate-limit": "^8.0.1",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^18.16.0",
     "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,67 +7,80 @@ import { createChequeRoutes, createHealthRoutes } from "./routes/chequeRoutes";
 import { globalRequestLimiter } from "./middleware/rateLimiter";
 import { requestLogger } from "./middleware/logger";
 
-// Get application configuration
-const config = getConfig();
+// Function to create the Express app
+export function createApp() {
+  // Get application configuration
+  const config = getConfig();
 
-// Initialize Express app
-const app = express();
+  // Initialize Express app
+  const app = express();
 
-// Security: Disable X-Powered-By header to hide Express.js version info
-app.disable("x-powered-by");
+  // Security: Disable X-Powered-By header to hide Express.js version info
+  app.disable("x-powered-by");
 
-// Initialize services and controllers
-const chequeService = new ChequeVerificationService(config.apiUrl);
-const chequeController = new ChequeController(chequeService);
+  // Initialize services and controllers
+  const chequeService = new ChequeVerificationService(config.apiUrl);
+  const chequeController = new ChequeController(chequeService);
 
-// Apply global rate limiting to all requests
-app.use(globalRequestLimiter);
+  // Apply global rate limiting to all requests
+  app.use(globalRequestLimiter);
 
-// Enable JSON parsing with size limits
-app.use(express.json({ limit: "100kb" })); // Limiting request body size
+  // Enable JSON parsing with size limits
+  app.use(express.json({ limit: "100kb" })); // Limiting request body size
 
-// Trust proxy settings for accurate IP detection
-app.set("trust proxy", 1);
+  // Trust proxy settings for accurate IP detection
+  app.set("trust proxy", 1);
 
-// Enable CORS for frontend requests with more specific configuration
-app.use(
-  cors({
-    origin: config.frontendUrl, // Use configured frontend URL
-    methods: ["GET", "POST"], // Allow GET and POST
-    credentials: false, // Don't allow credentials
-  })
-);
+  // Enable CORS for frontend requests with more specific configuration
+  app.use(
+    cors({
+      origin: config.frontendUrl, // Use configured frontend URL
+      methods: ["GET", "POST"], // Allow GET and POST
+      credentials: false, // Don't allow credentials
+    })
+  );
 
-// Simple request logger middleware
-app.use(requestLogger);
+  // Simple request logger middleware
+  app.use(requestLogger);
 
-// Configure routes
-app.use("/api/cheque", createChequeRoutes(chequeController));
-app.use("/health", createHealthRoutes(chequeController));
+  // Configure routes
+  app.use("/api/cheque", createChequeRoutes(chequeController));
+  app.use("/health", createHealthRoutes(chequeController));
 
-// Start server and store reference
-const server = app.listen(config.port, () => {
-  console.log(`Backend server running on port ${config.port}`);
-  console.log(`Connected to API at ${config.apiUrl}`);
-  console.log(`Environment: ${config.environment}`);
-});
+  return app;
+}
 
-// Handle graceful shutdown
-process.on("SIGTERM", () => {
-  console.log("SIGTERM received. Shutting down gracefully...");
-  server.close(() => {
-    console.log("Server closed successfully");
-    process.exit(0);
+// Create app instance
+const app = createApp();
+
+// Only start server if this file is run directly (not imported for testing)
+if (require.main === module) {
+  const config = getConfig();
+
+  // Start server and store reference
+  const server = app.listen(config.port, () => {
+    console.log(`Backend server running on port ${config.port}`);
+    console.log(`Connected to API at ${config.apiUrl}`);
+    console.log(`Environment: ${config.environment}`);
   });
-});
 
-process.on("SIGINT", () => {
-  console.log("SIGINT received. Shutting down gracefully...");
-  server.close(() => {
-    console.log("Server closed successfully");
-    process.exit(0);
+  // Handle graceful shutdown
+  process.on("SIGTERM", () => {
+    console.log("SIGTERM received. Shutting down gracefully...");
+    server.close(() => {
+      console.log("Server closed successfully");
+      process.exit(0);
+    });
   });
-});
+
+  process.on("SIGINT", () => {
+    console.log("SIGINT received. Shutting down gracefully...");
+    server.close(() => {
+      console.log("Server closed successfully");
+      process.exit(0);
+    });
+  });
+}
 
 // Export app for testing
 export { app };


### PR DESCRIPTION
Introduces JWT-based authentication middleware to the API, securing cheque routes and allowing bypass for tests and health checks. Updates environment configuration for JWT settings in both API and backend. Backend now signs and sends JWTs when calling the API. Adds jsonwebtoken and related type dependencies to both projects.