### PR TITLE
Remove tsconfig.json from .dockerignore

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -23,5 +23,4 @@ __tests__
 *.spec.ts
 .eslintrc*
 .prettierrc*
-tsconfig.json
 vitest.config.ts


### PR DESCRIPTION
Allows tsconfig.json to be included in Docker build context, which is necessary for TypeScript tooling or builds inside the container.