### PR TITLE
Add imagePullSecrets to backend and frontend deployments

### DIFF
--- a/helm/cheque-verification-backend/templates/deployment.yaml
+++ b/helm/cheque-verification-backend/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: cheque-verification-backend
     spec:
+      imagePullSecrets:
+        - name: github-docker-registry
       containers:
         - name: cheque-verification-backend
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/cheque-verification-frontend/templates/deployment.yaml
+++ b/helm/cheque-verification-frontend/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app.kubernetes.io/name: cheque-verification-frontend
     spec:
+      imagePullSecrets:
+        - name: github-docker-registry
       containers:
         - name: cheque-verification-frontend
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Configured both backend and frontend Helm deployment templates to use the 'github-docker-registry' imagePullSecret. This allows Kubernetes to pull images from a private GitHub Docker registry.