### PR TITLE
Remove DATABASE_URL secret from deployment and values

### DIFF
--- a/helm/cheque-verification-backend/templates/deployment.yaml
+++ b/helm/cheque-verification-backend/templates/deployment.yaml
@@ -23,13 +23,6 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            {{- if .Values.secrets.DATABASE_URL }}
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.DATABASE_URL.secretName }}
-                  key: {{ .Values.secrets.DATABASE_URL.key }}
-            {{- end }}
             {{- if .Values.secrets.JWT_SECRET }}
             - name: JWT_SECRET
               valueFrom:

--- a/helm/cheque-verification-backend/values.yaml
+++ b/helm/cheque-verification-backend/values.yaml
@@ -40,9 +40,6 @@ readinessProbe:
 
 # Secrets (will be created separately)
 secrets:
-  DATABASE_URL:
-    secretName: cheque-verification-backend-secrets
-    key: DATABASE_URL
   JWT_SECRET:
     secretName: cheque-verification-backend-secrets
     key: JWT_SECRET


### PR DESCRIPTION
The DATABASE_URL environment variable and its secret reference have been removed from the deployment template and values.yaml. The backend only uses an API and does not connect directly to the DB