### PR TITLE
Update frontend service port from 3000 to 8080

### DIFF
--- a/helm/cheque-verification-frontend/templates/route.yaml
+++ b/helm/cheque-verification-frontend/templates/route.yaml
@@ -9,6 +9,6 @@ spec:
     kind: Service
     name: cheque-verification-frontend
   port:
-    targetPort: 3000
+    targetPort: 8080
   tls:
     termination: edge

--- a/helm/cheque-verification-frontend/templates/service.yaml
+++ b/helm/cheque-verification-frontend/templates/service.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: 3000
+      targetPort: 8080

--- a/helm/cheque-verification-frontend/values.yaml
+++ b/helm/cheque-verification-frontend/values.yaml
@@ -7,7 +7,7 @@ image:
 
 service:
   type: ClusterIP
-  port: 3000
+  port: 8080
 
 resources: {}
 


### PR DESCRIPTION
Changed the targetPort and service port values from 3000 to 8080 in Helm templates and values.yaml for cheque-verification-frontend. This aligns the configuration with the new application port.