### PR TITLE
Remove tsconfig.json from .dockerignore

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -16,4 +16,3 @@ coverage
 .idea
 __tests__
 jest.config.js
-tsconfig.json


### PR DESCRIPTION
Allows tsconfig.json to be included in Docker build context, which is necessary for TypeScript compilation or tooling during the build process.