### PR TITLE
Inject VITE_API_URL into frontend build process

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    environment:
+      name: test
     permissions:
       contents: read
       packages: write
@@ -45,6 +47,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
+          build-args: |
+            VITE_API_URL=${{ secrets.VITE_API_URL }}
 
       # Build backend image
       - name: Extract metadata for backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,8 +7,14 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Copy source and build
+# Copy source code
 COPY . ./
+
+# Accept build argument for API URL and make it available to Vite
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
+# Build the application with injected API URL
 RUN npm run build
 
 # Production stage - serve with Node.js

--- a/helm/cheque-verification-backend/templates/route.yaml
+++ b/helm/cheque-verification-backend/templates/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: cheque-verification-backend
+  labels:
+    app.kubernetes.io/name: cheque-verification-backend
+spec:
+  to:
+    kind: Service
+    name: cheque-verification-backend
+  port:
+    targetPort: 80
+  tls:
+    termination: edge


### PR DESCRIPTION
Adds support for passing the VITE_API_URL as a build argument in the frontend Dockerfile and updates the GitHub Actions workflow to provide this value from secrets. This enables dynamic configuration of the API endpoint during deployment to the test environment.