### PR TITLE
Enable trust proxy setting in Express app

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -15,6 +15,9 @@ export function createApp(options: CreateAppOptions = {}) {
 
   app.disable("x-powered-by");
 
+  // Trust proxy for X-Forwarded-For headers (required for OpenShift/rate limiting)
+  app.set("trust proxy", true);
+
   const origins = allowedOrigins?.length
     ? allowedOrigins
     : ["http://localhost:4000"];
@@ -36,12 +39,14 @@ export function createApp(options: CreateAppOptions = {}) {
     res.status(404).json({ success: false, error: "Not found" })
   );
 
-  app.use((err: HttpError, req: Request, res: Response, _next: NextFunction) => {
-    console.error(err.stack || err);
-    const status = err.statusCode || 500;
-    const message = err.message || "Internal server error";
-    res.status(status).json({ success: false, error: message });
-  });
+  app.use(
+    (err: HttpError, req: Request, res: Response, _next: NextFunction) => {
+      console.error(err.stack || err);
+      const status = err.statusCode || 500;
+      const message = err.message || "Internal server error";
+      res.status(status).json({ success: false, error: message });
+    }
+  );
 
   return app;
 }


### PR DESCRIPTION
Set 'trust proxy' to true to support X-Forwarded-For headers, which is required for deployments on OpenShift and for proper rate limiting. No other functional changes were made.