### PR TITLE
Replace console logging with logger in chequeService

### DIFF
--- a/api/__tests__/unit/chequeService.errors.test.ts
+++ b/api/__tests__/unit/chequeService.errors.test.ts
@@ -7,8 +7,25 @@ import {
   setupTestEnvironment,
 } from "../helpers/chequeTestHelpers";
 
+// Mock the logger before importing anything else
+jest.mock("../../src/config/logger.js", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+  },
+}));
+
+import { logger } from "../../src/config/logger.js";
+
 describe("ChequeService - Error Handling", () => {
   setupTestEnvironment();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe("getChequeFromDatabase - Error Scenarios", () => {
     it("throws_404_error_when_cheque_not_found_in_database", async () => {
@@ -139,7 +156,6 @@ describe("ChequeService - Error Handling", () => {
     it("handles_connection_close_failure_gracefully", async () => {
       // Arrange
       const mockConnection = createMockConnection();
-      const mockConsoleWarn = jest.spyOn(console, "warn").mockImplementation();
       const closeError = new Error("Connection close failed");
 
       const validChequeRow = createValidChequeRow();
@@ -157,12 +173,10 @@ describe("ChequeService - Error Handling", () => {
 
       // Assert
       expect(result).toBeDefined();
-      expect(mockConsoleWarn).toHaveBeenCalledWith(
-        "Failed to close database connection:",
-        closeError
+      expect(logger.warn).toHaveBeenCalledWith(
+        { error: closeError },
+        "Failed to close database connection"
       );
-
-      mockConsoleWarn.mockRestore();
     });
   });
 });

--- a/api/__tests__/unit/services/chequeService.logging.test.ts
+++ b/api/__tests__/unit/services/chequeService.logging.test.ts
@@ -1,253 +1,101 @@
 import {
   getChequeFromDatabase,
-  HttpError,
-  oracledb,
   createMockConnection,
   mockPool,
   setupTestEnvironment,
-  TEST_SCHEMA,
-  TEST_TABLE,
 } from "../../helpers/chequeTestHelpers";
+
+// Mock the logger before importing anything else
+jest.mock("../../../src/config/logger.js", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+  },
+}));
+
+import { logger } from "../../../src/config/logger.js";
 
 describe("ChequeService - Logging Coverage", () => {
   setupTestEnvironment();
 
-  describe("Console logging verification", () => {
-    let consoleSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    beforeEach(() => {
-      // Override the global console mocking for this specific test
-      consoleSpy = jest.spyOn(console, "log").mockImplementation();
-      jest.spyOn(console, "error").mockImplementation();
-      jest.spyOn(console, "warn").mockImplementation();
-    });
+  it("should log starting query info", async () => {
+    const mockConnection = createMockConnection();
+    mockConnection.execute.mockResolvedValue({ rows: [] });
+    mockPool.getConnection.mockResolvedValue(mockConnection);
 
-    afterEach(() => {
-      consoleSpy.mockRestore();
-    });
+    try {
+      await getChequeFromDatabase("123");
+    } catch (error) {
+      // Expected to throw
+    }
 
-    it("should log database configuration missing error", async () => {
-      // Temporarily remove environment variables
-      const originalSchema = process.env.DB_SCHEMA;
-      const originalTable = process.env.DB_TABLE;
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        chequeNumberLength: 3,
+        hasSchema: true,
+        hasTable: true,
+      },
+      "Starting cheque database query"
+    );
+  });
 
-      delete process.env.DB_SCHEMA;
-      delete process.env.DB_TABLE;
+  it("should log database connection establishment", async () => {
+    const mockConnection = createMockConnection();
+    mockConnection.execute.mockResolvedValue({ rows: [] });
+    mockPool.getConnection.mockResolvedValue(mockConnection);
 
-      const errorSpy = jest.spyOn(console, "error");
+    try {
+      await getChequeFromDatabase("123");
+    } catch (error) {
+      // Expected to throw
+    }
 
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw
-      }
+    expect(logger.info).toHaveBeenCalledWith("Database connection established");
+  });
 
-      expect(errorSpy).toHaveBeenCalledWith("Database configuration missing", {
-        schema: false,
-        table: false,
-      });
+  it("should log database errors", async () => {
+    const mockConnection = createMockConnection();
+    const testError = new Error("Connection timeout");
+    mockPool.getConnection.mockResolvedValue(mockConnection);
+    mockConnection.execute.mockRejectedValue(testError);
 
-      // Restore environment variables
-      process.env.DB_SCHEMA = originalSchema;
-      process.env.DB_TABLE = originalTable;
-    });
-
-    it("should log database query start with secure parameters", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [
-          {
-            CHEQUE_STATUS_OUTPUT: "VALID",
-            CHEQUE_NUMBER: "123456",
-            PAYMENT_ISSUE_DT: new Date(),
-            APPLIED_AMOUNT: 100,
-          },
-        ],
-      });
-
+    try {
       await getChequeFromDatabase("123456");
+    } catch (error) {
+      // Expected to throw
+    }
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Starting cheque database query",
-        {
-          chequeNumberLength: 6,
-          hasSchema: true,
-          hasTable: true,
-        }
-      );
-    });
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        errorType: "Error",
+        errorMessage: "Connection timeout",
+        errorCode: undefined,
+        hasMessage: true,
+      },
+      "Database error in getChequeFromDatabase"
+    );
+  });
 
-    it("should log database connection establishment", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [
-          {
-            CHEQUE_STATUS_OUTPUT: "VALID",
-            CHEQUE_NUMBER: "123456",
-            PAYMENT_ISSUE_DT: new Date(),
-            APPLIED_AMOUNT: 100,
-          },
-        ],
-      });
+  it("should log no rows returned warning", async () => {
+    const mockConnection = createMockConnection();
+    mockPool.getConnection.mockResolvedValue(mockConnection);
+    mockConnection.execute.mockResolvedValue({ rows: [] });
 
+    try {
       await getChequeFromDatabase("123456");
+    } catch (error) {
+      // Expected to throw
+    }
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Database connection established"
-      );
-    });
-
-    it("should log query completion with row count", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [
-          {
-            CHEQUE_STATUS_OUTPUT: "VALID",
-            CHEQUE_NUMBER: "123456",
-            PAYMENT_ISSUE_DT: new Date(),
-            APPLIED_AMOUNT: 100,
-          },
-        ],
-      });
-
-      await getChequeFromDatabase("123456");
-
-      expect(consoleSpy).toHaveBeenCalledWith("Database query completed", {
-        rowCount: 1,
-        hasResult: true,
-      });
-    });
-
-    it("should log when query result is found with secure data flags", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [
-          {
-            CHEQUE_STATUS_OUTPUT: "VALID",
-            CHEQUE_NUMBER: "123456",
-            PAYMENT_ISSUE_DT: new Date(),
-            APPLIED_AMOUNT: 100,
-          },
-        ],
-      });
-
-      await getChequeFromDatabase("123456");
-
-      expect(consoleSpy).toHaveBeenCalledWith("Query result found", {
-        hasStatusOutput: true,
-        hasPaymentDate: true,
-        hasAmount: true,
-        resultNumberLength: 6,
-      });
-    });
-
-    it("should log when no rows are returned from database", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [],
-      });
-
-      const warnSpy = jest.spyOn(console, "warn");
-
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw HttpError
-      }
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        "No rows returned from database query"
-      );
-    });
-
-    it("should log when cheque is not found", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [],
-      });
-
-      const warnSpy = jest.spyOn(console, "warn");
-
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw HttpError
-      }
-
-      expect(warnSpy).toHaveBeenCalledWith("Cheque not found in database");
-    });
-
-    it("should log database errors with secure error information", async () => {
-      const mockConnection = createMockConnection();
-      const testError = new Error("Connection timeout");
-
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockRejectedValueOnce(testError);
-
-      const errorSpy = jest.spyOn(console, "error");
-
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw
-      }
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Database error in getChequeFromDatabase",
-        {
-          errorType: "Error",
-          hasMessage: true,
-        }
-      );
-    });
-
-    it("should handle non-Error objects in database errors", async () => {
-      const mockConnection = createMockConnection();
-      const testError = "String error";
-
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockRejectedValueOnce(testError);
-
-      const errorSpy = jest.spyOn(console, "error");
-
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw
-      }
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Database error in getChequeFromDatabase",
-        {
-          errorType: "Unknown",
-          hasMessage: true,
-        }
-      );
-    });
-
-    it("should log query completion with zero rows", async () => {
-      const mockConnection = createMockConnection();
-      mockPool.getConnection.mockResolvedValueOnce(mockConnection);
-      mockConnection.execute.mockResolvedValueOnce({
-        rows: [],
-      });
-
-      try {
-        await getChequeFromDatabase("123456");
-      } catch (error) {
-        // Expected to throw
-      }
-
-      expect(consoleSpy).toHaveBeenCalledWith("Database query completed", {
-        rowCount: 0,
-        hasResult: false,
-      });
-    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "No rows returned from database query"
+    );
   });
 });

--- a/api/src/services/chequeService.ts
+++ b/api/src/services/chequeService.ts
@@ -2,8 +2,7 @@ import oracledb from "oracledb";
 import { ChequeStatusResponse } from "../types.js";
 import { getDbPool } from "../config/database.js";
 import { HttpError } from "../middleware/validation.js";
-// Temporary: using console.log for debugging instead of logger
-// import { logger } from "../config/logger.js";
+import { logger } from "../config/logger.js";
 
 // Define the database row type for better type safety
 interface ChequeRow {
@@ -23,26 +22,32 @@ export async function getChequeFromDatabase(
   const table = process.env.DB_TABLE;
 
   if (!schema || !table) {
-    console.error("Database configuration missing", {
-      schema: !!schema,
-      table: !!table,
-    });
+    logger.error(
+      {
+        schema: !!schema,
+        table: !!table,
+      },
+      "Database configuration missing"
+    );
     throw new Error(
       "Database schema and table not configured in environment variables"
     );
   }
 
-  console.log("Starting cheque database query", {
-    chequeNumberLength: chequeNumber?.length || 0,
-    hasSchema: !!schema,
-    hasTable: !!table,
-  });
+  logger.info(
+    {
+      chequeNumberLength: chequeNumber?.length || 0,
+      hasSchema: !!schema,
+      hasTable: !!table,
+    },
+    "Starting cheque database query"
+  );
 
   try {
     const dbPool = getDbPool();
     connection = await dbPool.getConnection();
 
-    console.log("Database connection established");
+    logger.info("Database connection established");
 
     result = await connection.execute<ChequeRow>(
       `SELECT CHEQUE_STATUS_OUTPUT, CHEQUE_NUMBER, PAYMENT_ISSUE_DT, APPLIED_AMOUNT
@@ -52,34 +57,45 @@ export async function getChequeFromDatabase(
       { outFormat: oracledb.OUT_FORMAT_OBJECT }
     );
 
-    console.log("Database query completed", {
-      rowCount: result?.rows?.length || 0,
-      hasResult: !!result?.rows?.length,
-    });
+    logger.info(
+      {
+        rowCount: result?.rows?.length || 0,
+        hasResult: !!result?.rows?.length,
+      },
+      "Database query completed"
+    );
 
     // Log result status (without sensitive data) for debugging
     if (result?.rows?.length) {
-      console.log("Query result found", {
-        hasStatusOutput: !!result.rows[0].CHEQUE_STATUS_OUTPUT,
-        hasPaymentDate: !!result.rows[0].PAYMENT_ISSUE_DT,
-        hasAmount: !!result.rows[0].APPLIED_AMOUNT,
-        resultNumberLength: result.rows[0].CHEQUE_NUMBER?.length || 0,
-      });
+      logger.info(
+        {
+          hasStatusOutput: !!result.rows[0].CHEQUE_STATUS_OUTPUT,
+          hasPaymentDate: !!result.rows[0].PAYMENT_ISSUE_DT,
+          hasAmount: !!result.rows[0].APPLIED_AMOUNT,
+          resultNumberLength: result.rows[0].CHEQUE_NUMBER?.length || 0,
+        },
+        "Query result found"
+      );
     } else {
-      console.warn("No rows returned from database query");
+      logger.warn("No rows returned from database query");
     }
   } catch (error) {
-    console.error("Database error in getChequeFromDatabase", {
-      errorType: error instanceof Error ? error.constructor.name : "Unknown",
-      hasMessage: !!(error instanceof Error ? error.message : String(error)),
-    });
+    logger.error(
+      {
+        errorType: error instanceof Error ? error.constructor.name : "Unknown",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorCode: (error as any)?.code,
+        hasMessage: !!(error instanceof Error ? error.message : String(error)),
+      },
+      "Database error in getChequeFromDatabase"
+    );
     throw new Error("Failed to retrieve cheque information");
   } finally {
     await closeConnection(connection);
   }
 
   if (!result?.rows?.length) {
-    console.warn("Cheque not found in database");
+    logger.warn("Cheque not found in database");
     throw new HttpError("Cheque not found", 404);
   }
 
@@ -100,7 +116,7 @@ async function closeConnection(
     try {
       await connection.close();
     } catch (err) {
-      console.warn("Failed to close database connection:", err);
+      logger.warn({ error: err }, "Failed to close database connection");
     }
   }
 }


### PR DESCRIPTION
Refactored chequeService and related tests to use the centralized logger instead of console methods for all logging, including error, info, and warning messages. Updated tests to mock and assert logger calls, improving consistency and testability of logging behavior.