### PR TITLE
Use JSON log format in frontend Caddyfile

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -5,7 +5,7 @@
 :3000 {
 	log {
 		output stdout
-		format console
+		format json
 		level INFO
 	}
 	root * /srv


### PR DESCRIPTION
Switch the Caddy log format from "console" to "json" in frontend/Caddyfile so logs are emitted as structured JSON to stdout (level INFO). No other configuration changes were made.