### PR TITLE
Refactor Axios error handling and InlineAlert

### DIFF
--- a/frontend/__tests__/unit/pages/Home.test.tsx
+++ b/frontend/__tests__/unit/pages/Home.test.tsx
@@ -37,22 +37,9 @@ vi.mock("../../../src/components/ChequeForm", () => ({
 }));
 
 vi.mock("../../../src/components/InlineAlert", () => ({
-  default: ({
-    description,
-    variant,
-    title,
-  }: {
-    description: string;
-    variant?: string;
-    title?: string;
-  }) =>
+  default: ({ description }: { description: string }) =>
     description ? (
-      <div
-        data-testid="inline-alert"
-        data-variant={variant}
-        data-title={title}
-        role="alert"
-      >
+      <div data-testid="inline-alert" role="alert">
         {description}
       </div>
     ) : null,
@@ -369,8 +356,6 @@ describe("Home Page", () => {
       expect(alert).toHaveTextContent(
         "Too many requests. Please wait 2 minutes before trying again.",
       );
-      expect(alert).toHaveAttribute("data-variant", "warning");
-      expect(alert).toHaveAttribute("data-title", "Rate Limit");
     });
 
     // Should NOT set verification result status on 429
@@ -399,7 +384,6 @@ describe("Home Page", () => {
       expect(alert).toHaveTextContent(
         "Too many requests. Please wait a few minutes before trying again.",
       );
-      expect(alert).toHaveAttribute("data-variant", "warning");
     });
   });
 
@@ -424,7 +408,6 @@ describe("Home Page", () => {
       expect(alert).toHaveTextContent(
         "Too many requests. Please wait 1 minute before trying again.",
       );
-      expect(alert).toHaveAttribute("data-variant", "warning");
     });
   });
 
@@ -446,9 +429,7 @@ describe("Home Page", () => {
 
     await waitFor(() => {
       const alert = screen.getByTestId("inline-alert");
-      // variant and title are not set — InlineAlert defaults to danger/Error
-      expect(alert).not.toHaveAttribute("data-variant", "warning");
-      expect(alert).not.toHaveAttribute("data-title", "Rate Limit");
+      expect(alert).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -32,14 +32,9 @@ const formatValidationErrors = (details: string[]): string => {
 /**
  * Handles axios error responses and returns appropriate error message
  */
-const handleAxiosError = (
-  err: unknown,
-): { message: string; isRateLimited: boolean } => {
+const handleAxiosError = (err: unknown): string => {
   if (!axios.isAxiosError(err) || !err.response) {
-    return {
-      message: "Failed to verify cheque. Please try again later.",
-      isRateLimited: false,
-    };
+    return "Failed to verify cheque. Please try again later.";
   }
 
   const errorData = err.response.data;
@@ -49,30 +44,20 @@ const handleAxiosError = (
       errorData?.retryAfter ||
       Number(err.response.headers?.["retry-after"]) ||
       0;
-    return {
-      message: formatRateLimitError(retryAfter),
-      isRateLimited: true,
-    };
+    return formatRateLimitError(retryAfter);
   }
 
   if (errorData.details && Array.isArray(errorData.details)) {
-    return {
-      message: formatValidationErrors(errorData.details),
-      isRateLimited: false,
-    };
+    return formatValidationErrors(errorData.details);
   }
 
-  return {
-    message: errorData.error || "Verification failed",
-    isRateLimited: false,
-  };
+  return errorData.error || "Verification failed";
 };
 
 function Home() {
   const [status, setStatus] = useState<ApiResponse<CheckStatus> | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [isRateLimited, setIsRateLimited] = useState(false);
 
   /**
    * Handles cheque verification form submission
@@ -103,7 +88,6 @@ function Home() {
     try {
       setLoading(true);
       setError("");
-      setIsRateLimited(false);
       setStatus(null);
       // Use relative URL - Caddy handles routing to backend
       const response = await axios.post<ApiResponse<CheckStatus>>(
@@ -116,11 +100,13 @@ function Home() {
       );
       setStatus(response.data);
     } catch (err) {
-      const result = handleAxiosError(err);
-      setError(result.message);
-      setIsRateLimited(result.isRateLimited);
+      setError(handleAxiosError(err));
 
-      if (!result.isRateLimited && axios.isAxiosError(err) && err.response) {
+      if (
+        axios.isAxiosError(err) &&
+        err.response &&
+        err.response.status !== 429
+      ) {
         setStatus(err.response.data as ApiResponse<CheckStatus>);
       }
     } finally {
@@ -182,11 +168,7 @@ function Home() {
           message “Error. Cheque not found.”
         </p>
         <ChequeForm onSubmit={handleChequeSubmit} loading={loading} />
-        <InlineAlert
-          variant={isRateLimited ? "warning" : undefined}
-          title={isRateLimited ? "Rate Limit" : undefined}
-          description={error}
-        />
+        <InlineAlert description={error} />
         <VerificationResult status={status} />
       </div>
     </main>


### PR DESCRIPTION
Simplify error handling by making handleAxiosError return a string message (instead of an object) and removing the isRateLimited state. Update Home to setError directly, avoid updating status for 429 responses, and remove conditional InlineAlert props. Adjust unit tests and the InlineAlert mock to only rely on the description (remove checks for variant/title attributes). These changes streamline error flow and UI rendering for rate-limited and other error cases.