### PR TITLE
Use module-level configPromise and update tests

### DIFF
--- a/frontend/__tests__/unit/components/AlertBanners.test.tsx
+++ b/frontend/__tests__/unit/components/AlertBanners.test.tsx
@@ -1,23 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen, act } from "@testing-library/react";
 import { renderWithProviders } from "../../helpers/testHelpers";
-import AlertBanners from "../../../src/components/AlertBanners";
+import type { AppConfig } from "../../../src/utils/config";
 
-// Mock the config utility
-vi.mock("../../../src/utils/config", () => ({
-  fetchConfig: vi.fn(),
-}));
+// Each test re-imports AlertBanners in isolation so the module-level
+// configPromise is recreated with the correct mock value for that test.
+async function setup(config: AppConfig) {
+  const fetchConfig = vi.fn().mockResolvedValue(config);
+  vi.doMock("../../../src/utils/config", () => ({ fetchConfig }));
 
-import { fetchConfig } from "../../../src/utils/config";
-const mockFetchConfig = vi.mocked(fetchConfig);
+  const { default: AlertBanners } =
+    await import("../../../src/components/AlertBanners");
+
+  return { AlertBanners, fetchConfig };
+}
 
 describe("AlertBanners", () => {
-  beforeEach(() => {
-    mockFetchConfig.mockReset();
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
   });
 
   it("renders nothing when both banners are disabled", async () => {
-    mockFetchConfig.mockResolvedValue({
+    const { AlertBanners, fetchConfig } = await setup({
       bannerUpdateIssue: false,
       bannerOutage: false,
     });
@@ -27,12 +32,12 @@ describe("AlertBanners", () => {
       ({ container } = renderWithProviders(<AlertBanners />));
     });
 
-    expect(mockFetchConfig).toHaveBeenCalled();
+    expect(fetchConfig).toHaveBeenCalled();
     expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("renders the update issue banner when enabled", async () => {
-    mockFetchConfig.mockResolvedValue({
+    const { AlertBanners } = await setup({
       bannerUpdateIssue: true,
       bannerOutage: false,
     });
@@ -48,7 +53,7 @@ describe("AlertBanners", () => {
   });
 
   it("renders the outage banner when enabled", async () => {
-    mockFetchConfig.mockResolvedValue({
+    const { AlertBanners } = await setup({
       bannerUpdateIssue: false,
       bannerOutage: true,
     });
@@ -66,7 +71,7 @@ describe("AlertBanners", () => {
   });
 
   it("renders both banners when both are enabled", async () => {
-    mockFetchConfig.mockResolvedValue({
+    const { AlertBanners } = await setup({
       bannerUpdateIssue: true,
       bannerOutage: true,
     });
@@ -83,23 +88,24 @@ describe("AlertBanners", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders nothing when config fetch returns all-disabled defaults", async () => {
-    mockFetchConfig.mockResolvedValue({
-      bannerUpdateIssue: false,
-      bannerOutage: false,
-    });
+  it("renders nothing when config fetch fails", async () => {
+    const fetchConfig = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.doMock("../../../src/utils/config", () => ({ fetchConfig }));
+
+    const { default: AlertBanners } =
+      await import("../../../src/components/AlertBanners");
 
     let container!: HTMLElement;
     await act(async () => {
       ({ container } = renderWithProviders(<AlertBanners />));
     });
 
-    expect(mockFetchConfig).toHaveBeenCalled();
+    expect(fetchConfig).toHaveBeenCalled();
     expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("uses warning variant for banners", async () => {
-    mockFetchConfig.mockResolvedValue({
+    const { AlertBanners } = await setup({
       bannerUpdateIssue: true,
       bannerOutage: false,
     });
@@ -112,5 +118,27 @@ describe("AlertBanners", () => {
     const banner = container.querySelector('[role="alert"]');
     expect(banner).not.toBeNull();
     expect((banner as HTMLElement).dataset.variant).toBe("warning");
+  });
+
+  it("only fetches config once regardless of re-renders", async () => {
+    const { AlertBanners, fetchConfig } = await setup({
+      bannerUpdateIssue: false,
+      bannerOutage: false,
+    });
+
+    await act(async () => {
+      renderWithProviders(<AlertBanners />);
+    });
+    await act(async () => {
+      renderWithProviders(<AlertBanners />);
+    });
+    await act(async () => {
+      renderWithProviders(<AlertBanners />);
+    });
+
+    // fetchConfig must be called exactly once — the promise is module-level.
+    // If this fails it means fetchConfig was moved inside the component,
+    // which would cause a request loop when Suspense retries.
+    expect(fetchConfig).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/AlertBanners.tsx
+++ b/frontend/src/components/AlertBanners.tsx
@@ -1,7 +1,18 @@
-import { use, useState, Suspense } from "react";
+import { use, Suspense } from "react";
 import { AlertBanner } from "@bcgov/design-system-react-components";
 import { fetchConfig } from "../utils/config";
 import type { AppConfig } from "../utils/config";
+
+const defaultConfig: AppConfig = {
+  bannerUpdateIssue: false,
+  bannerOutage: false,
+};
+
+// Module-level singleton — created once on load, never re-fetched on re-render.
+// This is the correct pattern for use() with Suspense.
+const configPromise: Promise<AppConfig> = fetchConfig().catch(
+  () => defaultConfig,
+);
 
 /**
  * Inner component that suspends until runtime config is resolved.
@@ -10,7 +21,6 @@ import type { AppConfig } from "../utils/config";
  * - BANNER_OUTAGE="true" — shows the system outage banner
  */
 function AlertBannersContent() {
-  const [configPromise] = useState<Promise<AppConfig>>(() => fetchConfig());
   const config = use(configPromise);
 
   if (!config.bannerUpdateIssue && !config.bannerOutage) {


### PR DESCRIPTION
Move config fetch to a module-level singleton (configPromise) with a default fallback to avoid repeated fetches on re-renders and to follow the correct use() + Suspense pattern. Remove the component-local useState-based fetch and catch fetch errors to return safe defaults. Update unit tests to mock fetchConfig per-test using vi.doMock, reset modules/mocks after each test, and re-import the component to recreate module-level state. Add a new test ensuring fetchConfig is only called once and a test for fetch failure behavior.