### PR TITLE
Add cheque form help text and action layout

### DIFF
--- a/frontend/__tests__/unit/components/ChequeForm.test.tsx
+++ b/frontend/__tests__/unit/components/ChequeForm.test.tsx
@@ -1,62 +1,71 @@
-import { describe, it, expect, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from '../../helpers/testHelpers';
-import ChequeForm from '../../../src/components/ChequeForm';
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../helpers/testHelpers";
+import ChequeForm from "../../../src/components/ChequeForm";
 
-describe('ChequeForm', () => {
-  it('renders the required inputs and submit button', () => {
+describe("ChequeForm", () => {
+  it("renders the required inputs and submit button", () => {
     renderWithProviders(<ChequeForm onSubmit={vi.fn()} loading={false} />);
 
-    expect(screen.getByLabelText('Cheque Number')).toBeInTheDocument();
-    expect(screen.getByLabelText('Payment Issue Date')).toBeInTheDocument();
-    expect(screen.getByLabelText('Cheque Amount')).toBeInTheDocument();
+    expect(screen.getByLabelText("Cheque Number")).toBeInTheDocument();
+    expect(screen.getByLabelText("Payment Issue Date")).toBeInTheDocument();
+    expect(screen.getByLabelText("Cheque Amount")).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /verify cheque/i })
+      screen.getByRole("button", { name: /verify cheque/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Having trouble finding a cheque or seeing the expected status?",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "report" })).toHaveAttribute(
+      "href",
+      "#report",
+    );
   });
 
-  it('blocks submission and shows validation feedback when fields are empty', async () => {
+  it("blocks submission and shows validation feedback when fields are empty", async () => {
     const handleSubmit = vi.fn();
     const user = userEvent.setup();
 
     renderWithProviders(<ChequeForm onSubmit={handleSubmit} loading={false} />);
 
-    await user.click(screen.getByRole('button', { name: /verify cheque/i }));
+    await user.click(screen.getByRole("button", { name: /verify cheque/i }));
 
-    const alerts = screen.getAllByRole('alert');
-    expect(alerts[0]).toHaveTextContent('Please enter a cheque number');
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts[0]).toHaveTextContent("Please enter a cheque number");
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
-  it('submits the collected values when the form is valid', async () => {
+  it("submits the collected values when the form is valid", async () => {
     const handleSubmit = vi.fn().mockResolvedValue(undefined);
     const user = userEvent.setup();
 
     renderWithProviders(<ChequeForm onSubmit={handleSubmit} loading={false} />);
 
-    await user.type(screen.getByLabelText('Cheque Number'), '123456');
-    await user.type(screen.getByLabelText('Payment Issue Date'), '2024-01-15');
-    await user.type(screen.getByLabelText('Cheque Amount'), '1000.50');
-    await user.click(screen.getByRole('button', { name: /verify cheque/i }));
+    await user.type(screen.getByLabelText("Cheque Number"), "123456");
+    await user.type(screen.getByLabelText("Payment Issue Date"), "2024-01-15");
+    await user.type(screen.getByLabelText("Cheque Amount"), "1000.50");
+    await user.click(screen.getByRole("button", { name: /verify cheque/i }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
-        chequeNumber: '123456',
-        paymentIssueDate: '2024-01-15',
-        appliedAmount: '1000.5',
+        chequeNumber: "123456",
+        paymentIssueDate: "2024-01-15",
+        appliedAmount: "1000.5",
       });
     });
 
     expect(
-      screen.queryByText('Please enter a cheque number')
+      screen.queryByText("Please enter a cheque number"),
     ).not.toBeInTheDocument();
   });
 
-  it('disables the submit button while loading', () => {
+  it("disables the submit button while loading", () => {
     renderWithProviders(<ChequeForm onSubmit={vi.fn()} loading={true} />);
 
-    const submitButton = screen.getByRole('button', { name: /loading/i });
+    const submitButton = screen.getByRole("button", { name: /loading/i });
     expect(submitButton).toBeDisabled();
   });
 });

--- a/frontend/__tests__/unit/components/ChequeForm.test.tsx
+++ b/frontend/__tests__/unit/components/ChequeForm.test.tsx
@@ -19,10 +19,13 @@ describe("ChequeForm", () => {
         "Having trouble finding a cheque or seeing the expected status?",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "report" })).toHaveAttribute(
+    const helpLink = screen.getByRole("link", { name: "request help" });
+    expect(helpLink).toHaveAttribute(
       "href",
-      "#report",
+      "https://submit.digital.gov.bc.ca/app/form/submit?f=7d2f8c2e-7107-4273-8d53-a81c1b76fb44",
     );
+    expect(helpLink).toHaveAttribute("target", "_blank");
+    expect(helpLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("blocks submission and shows validation feedback when fields are empty", async () => {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -47,9 +47,19 @@
 /* Base Styles */
 body {
   margin: 0;
-  font-family: "BC Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
-    "Helvetica Neue", sans-serif;
+  font-family:
+    "BC Sans",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Roboto",
+    "Oxygen",
+    "Ubuntu",
+    "Cantarell",
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--bcgov-background-light-gray);
@@ -103,4 +113,26 @@ body {
 
 .font-BCSans {
   font-family: "BC Sans", sans-serif;
+}
+
+.cheque-form-actions {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: center;
+  gap: 24px;
+  width: 100%;
+}
+
+.cheque-form-help {
+  margin: 0;
+  max-width: 460px;
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+@media (max-width: 600px) {
+  .cheque-form-actions {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
 }

--- a/frontend/src/components/ChequeForm.tsx
+++ b/frontend/src/components/ChequeForm.tsx
@@ -101,7 +101,7 @@ const ChequeForm = ({
           <InlineAlert description={localError} />
         </div>
       )}
-      <div style={{ width: "100%" }}>
+      <div className="cheque-form-actions">
         <Button
           type="submit"
           variant="primary"
@@ -111,6 +111,22 @@ const ChequeForm = ({
         >
           Verify Cheque
         </Button>
+        <p className="cheque-form-help">
+          <strong>
+            Having trouble finding a cheque or seeing the expected status?
+          </strong>
+          <br />
+          The portal refreshes every 15 minutes. If 15 minutes have passed and
+          the issue persists, please{" "}
+          <a
+            href="https://submit.digital.gov.bc.ca/app/form/submit?f=7d2f8c2e-7107-4273-8d53-a81c1b76fb44"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            request help
+          </a>{" "}
+          it for review.
+        </p>
       </div>
     </form>
   );


### PR DESCRIPTION
Updates `ChequeForm` to show a support/help message with an external request-help link beside the submit button, and replaces inline button container styling with reusable CSS classes. Adds responsive styles for the action/help row in `App.css` and expands unit tests to cover the new help copy/link while keeping existing submit/validation behavior checks.