### PR TITLE
Improve help text and mobile layout in ChequeForm

### DIFF
--- a/frontend/__tests__/unit/components/ChequeForm.test.tsx
+++ b/frontend/__tests__/unit/components/ChequeForm.test.tsx
@@ -19,7 +19,17 @@ describe("ChequeForm", () => {
         "Having trouble finding a cheque or seeing the expected status?",
       ),
     ).toBeInTheDocument();
-    const helpLink = screen.getByRole("link", { name: "request help" });
+    expect(
+      screen.getByText(
+        /The portal refreshes every 15 minutes\. If the expected cheque information is still unavailable after 15 minutes, please submit a/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /If the issue is urgent and affecting client service, please contact the Cheque Verification Line\./,
+      ),
+    ).toBeInTheDocument();
+    const helpLink = screen.getByRole("link", { name: "Report an Issue" });
     expect(helpLink).toHaveAttribute(
       "href",
       "https://submit.digital.gov.bc.ca/app/form/submit?f=7d2f8c2e-7107-4273-8d53-a81c1b76fb44",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -117,22 +117,30 @@ body {
 
 .cheque-form-actions {
   display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
+  grid-template-columns: 1fr;
   align-items: center;
-  gap: 24px;
+  gap: 16px;
   width: 100%;
 }
 
 .cheque-form-help {
   margin: 0;
-  max-width: 460px;
+  max-width: 100%;
   font-size: 12px;
   line-height: 1.3;
 }
 
-@media (max-width: 600px) {
+.cheque-form-help-link {
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
   .cheque-form-actions {
-    grid-template-columns: 1fr;
-    gap: 16px;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 24px;
+  }
+
+  .cheque-form-help {
+    max-width: 460px;
   }
 }

--- a/frontend/src/components/ChequeForm.tsx
+++ b/frontend/src/components/ChequeForm.tsx
@@ -116,16 +116,18 @@ const ChequeForm = ({
             Having trouble finding a cheque or seeing the expected status?
           </strong>
           <br />
-          The portal refreshes every 15 minutes. If 15 minutes have passed and
-          the issue persists, please{" "}
+          The portal refreshes every 15 minutes. If the expected cheque
+          information is still unavailable after 15 minutes, please submit a{" "}
           <a
+            className="cheque-form-help-link"
             href="https://submit.digital.gov.bc.ca/app/form/submit?f=7d2f8c2e-7107-4273-8d53-a81c1b76fb44"
             target="_blank"
             rel="noopener noreferrer"
           >
-            request help
+            <strong>Report an Issue</strong>
           </a>{" "}
-          it for review.
+          request for investigation. If the issue is urgent and affecting client
+          service, please contact the Cheque Verification Line.
         </p>
       </div>
     </form>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -155,18 +155,6 @@ function Home() {
             Verify Your Cheque Details
           </h2>
         </div>
-        <p
-          style={{
-            padding: "16px 16px 0 16px",
-            margin: "0",
-            fontSize: "14px",
-            color: "var(--bcgov-text-dark)",
-            lineHeight: "1.5",
-          }}
-        >
-          Please call the cheque verification line if the portal returns the
-          message “Error. Cheque not found.”
-        </p>
         <ChequeForm onSubmit={handleChequeSubmit} loading={loading} />
         <InlineAlert description={error} />
         <VerificationResult status={status} />


### PR DESCRIPTION
Updates the help text to clarify refresh behaviour and link wording ('Report an Issue'). Removes the redundant 'cheque not found' paragraph from Home. Fixes responsive layout to use mobile-first approach (single column default, two columns at 768px+).